### PR TITLE
Parses URLs in content automatically into links

### DIFF
--- a/views/default/anypage/content.php
+++ b/views/default/anypage/content.php
@@ -13,4 +13,6 @@ if (!$page) {
 	return;
 }
 
-echo $page->description;
+echo elgg_view('output/longtext', array(
+	'value' => $page->description
+));

--- a/views/default/object/anypage.php
+++ b/views/default/object/anypage.php
@@ -6,4 +6,6 @@
 $page = elgg_extract('entity', $vars);
 
 echo elgg_view_title($page->title);
-echo $page->description;
+echo elgg_view('output/longtext', array(
+	'value' => $page->description
+));


### PR DESCRIPTION
This runs the anypage content through ```output/longtext``` view which parses URLs automatically into links and also makes theming easier by wrapping the output inside .elgg-output div.

@mrclay Would this break any of the use cases for the ```anypage/content``` view that you added in d78d8d2351b44fbc625d09f8e2ee06260becbba0?